### PR TITLE
Allow extra parameters to be passed on to the column definition.

### DIFF
--- a/lib/migration_helper.rb
+++ b/lib/migration_helper.rb
@@ -6,10 +6,10 @@ module Ddb
       end
 
       module InstanceMethods
-        def userstamps(include_deleted_by = false)
-          column(Ddb::Userstamp.compatibility_mode ? :created_by : :creator_id, :integer)
-          column(Ddb::Userstamp.compatibility_mode ? :updated_by : :updater_id, :integer)
-          column(Ddb::Userstamp.compatibility_mode ? :deleted_by : :deleter_id, :integer) if include_deleted_by
+        def userstamps(include_deleted_by = false, *args)
+          column(Ddb::Userstamp.compatibility_mode ? :created_by : :creator_id, :integer, *args)
+          column(Ddb::Userstamp.compatibility_mode ? :updated_by : :updater_id, :integer, *args)
+          column(Ddb::Userstamp.compatibility_mode ? :deleted_by : :deleter_id, :integer, *args) if include_deleted_by
         end
       end
     end


### PR DESCRIPTION
This follows ActiveRecord's `timestamps` migration table definition helper method.